### PR TITLE
Add support for extensionless permalinks

### DIFF
--- a/README-GENERATOR.md
+++ b/README-GENERATOR.md
@@ -57,7 +57,9 @@ pagination:
   per_page: 10
 
   # The permalink structure for the paginated pages (this can be any level deep)
-  permalink: '/page/:num/'
+  permalink: '/page/:num/' # Pages are index.html inside this folder (default)
+  #permalink: '/page/:num.html' # Pages are simple html files 
+  #permalink: '/page/:num' # Pages are html files, linked jekyll extensionless permalink style.
 
   # Optional the title format for the paginated pages (supports :title for original page title, :num for pagination page number, :max for total number of pages)
   title: ':title - page :num'

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -251,9 +251,9 @@ module Jekyll
           paginated_page_url = config['permalink']
           first_index_page_url = ""
           if template.data['permalink']
-            first_index_page_url = template.data['permalink']+'/'
+            first_index_page_url = File.join(template.data['permalink'],"")
           else
-            first_index_page_url = template.dir+'/'
+            first_index_page_url = File.join(template.dir,"")
           end
           paginated_page_url = File.join(first_index_page_url, paginated_page_url)
           

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -251,9 +251,9 @@ module Jekyll
           paginated_page_url = config['permalink']
           first_index_page_url = ""
           if template.data['permalink']
-            first_index_page_url = template.data['permalink']
+            first_index_page_url = template.data['permalink']+'/'
           else
-            first_index_page_url = template.dir
+            first_index_page_url = template.dir+'/'
           end
           paginated_page_url = File.join(first_index_page_url, paginated_page_url)
           
@@ -261,7 +261,13 @@ module Jekyll
           newpage.pager = Paginator.new( config['per_page'], first_index_page_url, paginated_page_url, using_posts, cur_page_nr, total_pages)
 
           # Create the url for the new page, make sure we prepend any permalinks that are defined in the template page before
-          newpage.set_url(File.join(newpage.pager.page_path, 'index.html'))
+          if newpage.pager.page_path.end_with? '/'
+            newpage.set_url(File.join(newpage.pager.page_path, 'index.html'))
+          else
+            # Support for extensionless permalinks
+            newpage.set_url(newpage.pager.page_path+'.html')
+          end
+
           if( template.data['permalink'] )
             newpage.data['permalink'] = newpage.pager.page_path
           end

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -251,9 +251,9 @@ module Jekyll
           paginated_page_url = config['permalink']
           first_index_page_url = ""
           if template.data['permalink']
-            first_index_page_url = File.join(template.data['permalink'],"")
+            first_index_page_url = Utils.ensure_trailing_slash(template.data['permalink'])
           else
-            first_index_page_url = File.join(template.dir,"")
+            first_index_page_url = Utils.ensure_trailing_slash(template.dir)
           end
           paginated_page_url = File.join(first_index_page_url, paginated_page_url)
           
@@ -263,6 +263,9 @@ module Jekyll
           # Create the url for the new page, make sure we prepend any permalinks that are defined in the template page before
           if newpage.pager.page_path.end_with? '/'
             newpage.set_url(File.join(newpage.pager.page_path, 'index.html'))
+          elsif newpage.pager.page_path.end_with? '.html'
+            # Support for direct .html files
+            newpage.set_url(newpage.pager.page_path)
           else
             # Support for extensionless permalinks
             newpage.set_url(newpage.pager.page_path+'.html')

--- a/lib/jekyll-paginate-v2/generator/utils.rb
+++ b/lib/jekyll-paginate-v2/generator/utils.rb
@@ -52,6 +52,17 @@ module Jekyll
       def self.remove_leading_slash(path)
         path[0..0] == "/" ? path[1..-1] : path
       end
+      
+      # Static: Return a String version of the input which has a trailing slash.
+      #         If the input already has a forward slash at the end, it will be
+      #         returned unchanged.
+      #
+      # path - a String path
+      #
+      # Returns the path with a trailing slash
+      def self.ensure_trailing_slash(path)
+        path[-1] == "/" ? path : "#{path}/"
+      end
 
       #
       # Sorting routine used for ordering posts by custom fields.


### PR DESCRIPTION
Jekyll support [extensionless permalinks](https://jekyllrb.com/docs/permalinks/#extensionless-permalinks) when you omit the slash (/) from the end of your permalink setting. This patch adds support to the same capabilities to jekyll-paginate-v2.

Just omit the slash from the end of your permalink in the front matter, to generate .html files instead of folders.
```
pagination:
  enabled: true
  permalink: '/page:num'
```