### PR TITLE
AutoPage tag default typo fix

### DIFF
--- a/lib/jekyll-paginate-v2/autopages/defaults.rb
+++ b/lib/jekyll-paginate-v2/autopages/defaults.rb
@@ -6,7 +6,7 @@ module Jekyll
       'enabled'     => false,
       'tags'        => {
         'layouts'       => ['autopage_tags.html'],
-        'title'         => 'Posts tagged with :tag`',
+        'title'         => 'Posts tagged with :tag',
         'permalink'     => '/tag/:tag',
         'enabled'       => true
 


### PR DESCRIPTION
Hi, I found typo (extra ` character) in your default tag title.