### PR TITLE
Check if document has a date property before querying.

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -227,12 +227,14 @@ module Jekyll
             puts "Pagination: ".rjust(20) + "Rolling through the date fields for all documents"
           end
           for p in using_posts
-            tmp_date = p.date
-            if( !tmp_date || tmp_date.nil? )
-              if @debug
-                puts "Pagination: ".rjust(20) + "Explicitly assigning date for doc: #{p.data['title']} | #{p.path}"
+            if p.respond_to?('date')
+              tmp_date = p.date
+              if( !tmp_date || tmp_date.nil? )
+                if @debug
+                  puts "Pagination: ".rjust(20) + "Explicitly assigning date for doc: #{p.data['title']} | #{p.path}"
+                end
+                p.date = File.mtime(p.path)
               end
-              p.date = File.mtime(p.path)
             end
           end
 


### PR DESCRIPTION
The thing being asked for a `date` property is a `Jekyll::Document`.
Not all documents have a date (though most tend to), so this adds a
cautionary check.

As discussed in #29, I'm not sure of how idiomatic this type of check is. I have tested locally that it no longer crashes when hitting this code when paginating collections which don't have dates. I've also successfully built your three example sites in `examples/`.

Despite this, I'm not sure if that proves I haven't introduced a regression for #12 and 9fe7e3f0420, so you might want to double check that as I'm unfamiliar with that particular issue..

Fixes #29.