### PR TITLE
Create an option for setting a page file extension

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -13,9 +13,6 @@ module Jekyll
         @site = page_to_copy.site
         @base = ''
         @url = ''
-        @name = 'index.html'
-
-        self.process(@name) # Creates the basename and ext member values
 
         # Only need to copy the data part of the page as it already contains the layout information
         #self.data = Marshal.load(Marshal.dump(page_to_copy.data)) # Deep copying, http://stackoverflow.com/a/8206537/779521
@@ -32,6 +29,13 @@ module Jekyll
 
         # Store the current page and total page numbers in the pagination_info construct
         self.data['pagination_info'] = {"curr_page" => cur_page_nr, 'total_pages' => total_pages }
+
+        # Set the page extension
+        extension = self.data['pagination']['extension']
+        extension = extension.nil? ? '.html': '.' + extension
+        @name = 'index' + extension
+
+        self.process(@name) # Creates the basename and ext member values
 
         # Perform some validation that is also performed in Jekyll::Page
         validate_data! page_to_copy.path


### PR DESCRIPTION
The current implementation, will only generate html files from their respective templates. This PR adds an option for setting the generated page's file extension.

For example the following page template would generate a set of json files, based on the user's pagination settings.

```
---
layout: null
pagination:
  enabled: true
  extension: json
---

{
  "pages": [
  {% for post in paginator.posts %}
  {
    "Title": "{{ post.title }}"
  },
  {% endfor %}
  ]
}
```