### PR TITLE
Generate at least one page, issue #52

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -268,9 +268,7 @@ module Jekyll
         indexPageWithExt = indexPageName + indexPageExt
 
         # In case there are no (visible) posts, generate the index file anyway
-        if total_pages == 0
-          total_pages = 1
-        end
+        total_pages = 1 if total_pages.zero?
 
         # Now for each pagination page create it and configure the ranges for the collection
         # This .pager member is a built in thing in Jekyll and defines the paginator implementation

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -267,6 +267,11 @@ module Jekyll
         indexPageExt = Utils.ensure_leading_dot(config['extension'])
         indexPageWithExt = indexPageName + indexPageExt
 
+        # In case there are no (visible) posts, generate the index file anyway
+        if total_pages == 0
+          total_pages = 1
+        end
+
         # Now for each pagination page create it and configure the ranges for the collection
         # This .pager member is a built in thing in Jekyll and defines the paginator implementation
         # Simpy override to use mine


### PR DESCRIPTION
In cases where there are no posts (fresh site) or all the posts are hidden, no `index.html` is generated at the document root, leading to 404 errors from many/most hosting providers. This patch makes paginate-v2 always generate at least 1 page.

This fixes issue #52 