### PR TITLE
Feature: sticky posts

### DIFF
--- a/README-GENERATOR.md
+++ b/README-GENERATOR.md
@@ -75,6 +75,9 @@ pagination:
   # Optional, sorts the posts in reverse order (omit to default decending or sort_reverse: true)
   sort_reverse: true
 
+  # Optional, moves the posts tagged "sticky: true" to the start, after sorting
+  #sticky_first: true
+
   # Optional, the default category to use, omit or just leave this as 'posts' to get a backwards-compatible behavior (all posts)
   category: 'posts'
 

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -246,6 +246,21 @@ module Jekyll
           if config['sort_reverse']
             using_posts.reverse!
           end
+
+          # Do this here so the sticky posts still show up in the preferred order, only at the top
+          if config['sticky_first']
+            sticky_posts = []
+            using_posts.delete_if do |post|
+              if post.data['sticky']
+                if @debug
+                  puts "Sticky: ".rjust(20) + post.data['title']
+                end
+                sticky_posts << post
+                true
+              end
+            end
+            using_posts.unshift(*sticky_posts)
+          end
         end
                
         # Calculate the max number of pagination-pages based on the configured per page value


### PR DESCRIPTION
This adds a `sticky_first` option which makes posts tagged `sticky: true` appear before all other posts. Within the set of sticky posts, the sort order specified by the user (e.g. reversed, based on other fields, etc.) is still retained.