### PR TITLE
Check for nils, convert to DateTime before comparing

### DIFF
--- a/lib/jekyll-paginate-v2/generator/utils.rb
+++ b/lib/jekyll-paginate-v2/generator/utils.rb
@@ -84,6 +84,16 @@ module Jekyll
           return a.downcase <=> b.downcase
         end
         
+        if a.nil? && !b.nil?
+          return -1
+        elsif !a.nil? && b.nil?
+          return 1
+        end
+
+        if a.respond_to?('to_datetime') && b.respond_to?('to_datetime')
+          return a.to_datetime <=> b.to_datetime
+        end
+
         # By default use the built in sorting for the data type
         return a <=> b
       end


### PR DESCRIPTION
This compares `Date` (_YYYY-MM-DD_ only) and `Time` fields by doing a `to_datetime` first (if possible) so the comparison doesn't fail for custom sort date fields. It also checks for `nil`s since comparing it to e.g. a `Time` would also fail.

Should fix/help with issue #43 