### PR TITLE
Replace for loops with Enumerable#each

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,4 @@
 inherit_from: .rubocop_todo.yml
+
+Style/For:
+  EnforcedStyle: each

--- a/lib/jekyll-paginate-v2/autopages/utils.rb
+++ b/lib/jekyll-paginate-v2/autopages/utils.rb
@@ -25,7 +25,7 @@ module Jekyll
       # excludes all pagination pages though
       def self.collect_all_docs(site_collections)
         coll = []
-        for coll_name, coll_data in site_collections
+        site_collections.each do |coll_name, coll_data|
           if !coll_data.nil? 
             coll += coll_data.docs.select { |doc| !doc.data.has_key?('pagination') }.each{ |doc| doc.data['__coll'] = coll_name } # Exclude all pagination pages and then for every page store it's collection name
           end
@@ -37,7 +37,7 @@ module Jekyll
         return nil if all_posts.nil?
         return all_posts if index_key.nil?
         index = {}
-        for post in all_posts
+        all_posts.each do |post|
           next if post.data.nil?
           next if !post.data.has_key?(index_key)
           next if post.data[index_key].nil?
@@ -51,11 +51,11 @@ module Jekyll
             post_data = post_data.split(/;|,|\s/)
           end
           
-          for key in post_data
+          post_data.each do |key|
             key = key.strip
             # If the key is a delimetered list of values 
             # (meaning the user didn't use an array but a string with commas)
-            for raw_k_split in key.split(/;|,/)
+            key.split(/;|,/).each do |raw_k_split|
               k_split = raw_k_split.to_s.downcase.strip #Clean whitespace and junk
               if !index.has_key?(k_split)
                 # Need to store the original key value here so that I can present it to the users as a page variable they can use (unmodified, e.g. tags not being 'sci-fi' but "Sci-Fi")

--- a/lib/jekyll-paginate-v2/generator/paginationGenerator.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationGenerator.rb
@@ -74,7 +74,7 @@ module Jekyll
           if collection_name == "all"
             # the 'all' collection_name is a special case and includes all collections in the site (except posts!!)
             # this is useful when you want to list items across multiple collections
-            for coll_name, coll_data in site.collections
+            site.collections.each do |coll_name, coll_data|
               if( !coll_data.nil? && coll_name != 'posts')
                 coll += coll_data.docs.select { |doc| !doc.data.has_key?('pagination') } # Exclude all pagination pages
               end

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -12,7 +12,7 @@ module Jekyll
         return nil if all_posts.nil?
         return all_posts if index_key.nil?
         index = {}
-        for post in all_posts
+        all_posts.each do |post|
           next if post.data.nil?
           next if !post.data.has_key?(index_key)
           next if post.data[index_key].nil?
@@ -26,11 +26,11 @@ module Jekyll
             post_data = post_data.split(/;|,|\s/)
           end
           
-          for key in post_data
+          post_data.each do |key|
             key = key.to_s.downcase.strip
             # If the key is a delimetered list of values 
             # (meaning the user didn't use an array but a string with commas)
-            for k_split in key.split(/;|,/)
+            key.split(/;|,/).each do |k_split|
               k_split = k_split.to_s.downcase.strip #Clean whitespace and junk
               if !index.has_key?(k_split)
                 index[k_split.to_s] = []
@@ -79,7 +79,7 @@ module Jekyll
           
         # Now for all filter values for the config key, let's remove all items from the posts that
         # aren't common for all collections that the user wants to filter on
-        for key in config_value
+        config_value.each do |key|
           key = key.to_s.downcase.strip
           posts = PaginationIndexer.intersect_arrays(posts, source_posts[key])
         end

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -31,7 +31,7 @@ module Jekyll
         end
 
         # Now for each template page generate the paginator for it
-        for template in templates
+        templates.each do |template|
           # All pages that should be paginated need to include the pagination config element
           if template.data['pagination'].is_a?(Hash)
             template_config = Jekyll::Utils.deep_merge_hashes(default_config, template.data['pagination'] || {})
@@ -113,7 +113,7 @@ module Jekyll
 
         docs = []
         # Now for each of the collections get the docs
-        for coll_name in collection_names
+        collection_names.each do |coll_name|
           # Request all the documents for the collection in question, and join it with the total collection 
           docs += @collection_by_name_lambda.call(coll_name.downcase.strip)
         end
@@ -229,14 +229,14 @@ module Jekyll
           if @debug
             puts "Pagination: ".rjust(20) + "Rolling through the date fields for all documents"
           end
-          for p in using_posts
-            if p.respond_to?('date')
-              tmp_date = p.date
+          using_posts.each do |u_post|
+            if u_post.respond_to?('date')
+              tmp_date = u_post.date
               if( !tmp_date || tmp_date.nil? )
                 if @debug
-                  puts "Pagination: ".rjust(20) + "Explicitly assigning date for doc: #{p.data['title']} | #{p.path}"
+                  puts "Pagination: ".rjust(20) + "Explicitly assigning date for doc: #{u_post.data['title']} | #{u_post.path}"
                 end
-                p.date = File.mtime(p.path)
+                u_post.date = File.mtime(u_post.path)
               end
             end
           end

--- a/lib/jekyll-paginate-v2/generator/utils.rb
+++ b/lib/jekyll-paginate-v2/generator/utils.rb
@@ -107,7 +107,7 @@ module Jekyll
         sort_split = sort_field.split(":")
         sort_value = post_data
 
-        for r_key in sort_split
+        sort_split.each do |r_key|
           key = r_key.downcase.strip # Remove any erronious whitespace and convert to lower case
           if !sort_value.has_key?(key)
             return nil


### PR DESCRIPTION
Since `Enumerable#each` is faster than `for` loops. :slightly_smiling_face: 
Ref: https://github.com/JuanitoFatas/fast-ruby#enumerableeach-vs-for-loop-code