### PR TITLE
Add special_characters option to autopages tags, cats, and colls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Reach me at the [project issues](https://github.com/sverrirs/jekyll-paginate-v2/
 
 :heart:
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/zzB7QVjdsbLjtaFcQie3TDxC/sverrirs/jekyll-paginate-v2'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/zzB7QVjdsbLjtaFcQie3TDxC/sverrirs/jekyll-paginate-v2.svg' />
-</a>
-
 ## Installation
 
 ```

--- a/examples/01-typicalblog/_includes/header.html
+++ b/examples/01-typicalblog/_includes/header.html
@@ -14,11 +14,12 @@
       </span>
 
       <div class="trigger">
-        {% for my_page in site.pages %}
-          <!--
+        <!--
             my_page.autogen is populated by the pagination logic for all pages
                             that are automatically created by the gem. Check for non-existence to exclude pagination pages from site.pages iterators
           -->
+          
+        {% for my_page in site.pages %}
           {% if my_page.title and my_page.autogen == nil %}
           <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
           {% endif %}

--- a/examples/02-category/_includes/header.html
+++ b/examples/02-category/_includes/header.html
@@ -14,11 +14,11 @@
       </span>
 
       <div class="trigger">
-        {% for my_page in site.pages %}
-          <!--
+        <!--
             my_page.autogen is populated by the pagination logic for all pages
                             that are automatically created by the gem. Check for non-existence to exclude pagination pages from site.pages iterators
           -->
+        {% for my_page in site.pages %}
           {% if my_page.title and my_page.autogen == nil %}
           <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
           {% endif %}

--- a/examples/02-category/cars/_posts/2016-10-18-Porsche-918-Spyder.md
+++ b/examples/02-category/cars/_posts/2016-10-18-Porsche-918-Spyder.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Porsche 918 Spyder
 date:   2016-10-18 19:16:49 +0100
-categories: cars, grand touring, Porsche, sports car
+categories: cars, grand touring, Porsche, sports car, b+w
 ---
 _From Wikipedia, the free encyclopedia_
 

--- a/examples/02-category/categories/blackandwhite.md
+++ b/examples/02-category/categories/blackandwhite.md
@@ -1,0 +1,11 @@
+---
+layout: home
+title: Only black and white
+permalink: /b+w/
+pagination: 
+  enabled: true
+  category: b+w
+  permalink: /:num/
+  sort_field: 'title'
+  sort_reverse: false
+---

--- a/examples/03-tags/_config.yml
+++ b/examples/03-tags/_config.yml
@@ -47,7 +47,7 @@ autopages:
   tags: 
     layouts: 
       - autopage_collections_tags.html
-      - autopage_tags.html
+     # - autopage_tags.html
     enabled: true
   categories:
     layouts:
@@ -55,6 +55,9 @@ autopages:
     enabled: true
   collections:
     enabled: true
+    slugify:
+      mode: 'ascii'
+      cased: true  # Causes B+W tag to show up as it is written on the terry-pratchet-diary-2017.md page and not lowercase
     
   
 # This site uses the pretty permalink structure, this renders all urls with a slash / at the end and 

--- a/examples/03-tags/_fantasy/all/terry-pratchet-diary-2017.md
+++ b/examples/03-tags/_fantasy/all/terry-pratchet-diary-2017.md
@@ -14,7 +14,7 @@ book:
 price: 
   usd: 22.19
   eur: 20.97
-tags: Fantasy, Humor
+tags: Fantasy, Humor, B+W
 ---
 
 Sir Terry Pratchett left us, far too early, in March 2015. To celebrate his life and works, we've given over the 2017 Discworld Diary - which will be a perennial diary - to remembrances and tributes from some of those who knew and loved him and his extraordinary body of work. 

--- a/examples/03-tags/_includes/header.html
+++ b/examples/03-tags/_includes/header.html
@@ -14,15 +14,24 @@
       </span>
 
       <div class="trigger">
-        {% for my_page in site.pages %}
-          <!--
+        <!--
             my_page.autogen is populated by the pagination logic for all pages
                             that are automatically created by the gem. Check for non-existence to exclude pagination pages from site.pages iterators
-          -->
-          {% if my_page.title and my_page.autogen == nil %}
+          -->   
+        <p><b>Manual Pagination:</b><br>
+          {% for my_page in site.pages %}  
+            {% if my_page.title and my_page.autogen == nil and my_page.autopage == nil %}
+            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {% endif %}
+          {% endfor %}
+        </p>
+        <p><b>Autopage Created:</b><br>
+        {% for my_page in site.pages %}  
+          {% if my_page.title and my_page.autogen == nil and my_page.autopage != nil %}
           <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
           {% endif %}
         {% endfor %}
+        </p>
       </div>
     </nav>
 

--- a/examples/03-tags/_layouts/home.html
+++ b/examples/03-tags/_layouts/home.html
@@ -33,9 +33,6 @@ layout: default
     Showing buttons to move to the next and to the previous list of posts (pager buttons).
   -->
   {% if paginator.total_pages > 1 %}
-  {{page.url}}<br>
-  {{page.path}}<br>
-
   <ul class="pager">
       {% if paginator.first_page %}
       <li class="previous">

--- a/lib/jekyll-paginate-v2/autopages/defaults.rb
+++ b/lib/jekyll-paginate-v2/autopages/defaults.rb
@@ -8,20 +8,31 @@ module Jekyll
         'layouts'       => ['autopage_tags.html'],
         'title'         => 'Posts tagged with :tag',
         'permalink'     => '/tag/:tag',
-        'enabled'       => true
-
+        'enabled'       => true,
+        'slugify'       => {
+                              'mode' => 'none', # [raw default pretty ascii latin], none gives back the same string
+                              'cased'=> false # If cased is true, all uppercase letters in the result string are replaced with their lowercase counterparts.
+                            }
       },
       'categories'  => {
         'layouts'       => ['autopage_category.html'],
         'title'         => 'Posts in category :cat',
         'permalink'     => '/category/:cat',
-        'enabled'       => true
+        'enabled'       => true,
+        'slugify'       => {
+                              'mode' => 'none', # [raw default pretty ascii latin], none gives back the same string
+                              'cased'=> false # If cased is true, all uppercase letters in the result string are replaced with their lowercase counterparts.
+                            }
       },
       'collections' => {
         'layouts'       => ['autopage_collection.html'],
         'title'         => 'Posts in collection :coll',
         'permalink'     => '/collection/:coll',
-        'enabled'       => true
+        'enabled'       => true,
+        'slugify'       => {
+                              'mode' => 'none', # [raw default pretty ascii latin], none gives back the same string
+                              'cased'=> false # If cased is true, all uppercase letters in the result string are replaced with their lowercase counterparts.
+                            }
       } 
     }
 

--- a/lib/jekyll-paginate-v2/autopages/pages/categoryAutoPage.rb
+++ b/lib/jekyll-paginate-v2/autopages/pages/categoryAutoPage.rb
@@ -4,6 +4,9 @@ module Jekyll
     class CategoryAutoPage < BaseAutoPage
       def initialize(site, base, autopage_config, pagination_config, layout_name, category, category_name)
 
+        # Do we have a slugify configuration available
+        slugify_config = autopage_config.is_a?(Hash) && autopage_config.has_key?('slugify') ? autopage_config['slugify'] : nil
+
         # Construc the lambda function to set the config values
         # this function received the pagination config hash and manipulates it
         set_autopage_data_lambda = lambda do | in_config |
@@ -11,11 +14,11 @@ module Jekyll
         end
 
         get_autopage_permalink_lambda = lambda do |permalink_pattern|
-          return Utils.format_cat_macro(permalink_pattern, category, autopage_config['special_characters'])
+          return Utils.format_cat_macro(permalink_pattern, category, slugify_config)
         end
 
         get_autopage_title_lambda = lambda do |title_pattern|
-          return Utils.format_cat_macro(title_pattern, category, autopage_config['special_characters'])
+          return Utils.format_cat_macro(title_pattern, category, slugify_config)
         end
                 
         # Call the super constuctor with our custom lambda

--- a/lib/jekyll-paginate-v2/autopages/pages/collectionAutoPage.rb
+++ b/lib/jekyll-paginate-v2/autopages/pages/collectionAutoPage.rb
@@ -4,6 +4,9 @@ module Jekyll
     class CollectionAutoPage < BaseAutoPage
       def initialize(site, base, autopage_config, pagination_config, layout_name, collection, collection_name)
 
+        # Do we have a slugify configuration available
+        slugify_config = autopage_config.is_a?(Hash) && autopage_config.has_key?('slugify') ? autopage_config['slugify'] : nil
+
         # Construc the lambda function to set the config values
         # this function received the pagination config hash and manipulates it
         set_autopage_data_lambda = lambda do | in_config |
@@ -11,11 +14,11 @@ module Jekyll
         end
 
         get_autopage_permalink_lambda = lambda do |permalink_pattern|
-          return Utils.format_coll_macro(permalink_pattern, collection, autopage_config['special_characters'])
+          return Utils.format_coll_macro(permalink_pattern, collection, slugify_config)
         end
 
         get_autopage_title_lambda = lambda do |title_pattern|
-          return Utils.format_coll_macro(title_pattern, collection, autopage_config['special_characters'])
+          return Utils.format_coll_macro(title_pattern, collection, slugify_config)
         end
                 
         # Call the super constuctor with our custom lambda

--- a/lib/jekyll-paginate-v2/autopages/pages/tagAutoPage.rb
+++ b/lib/jekyll-paginate-v2/autopages/pages/tagAutoPage.rb
@@ -4,6 +4,9 @@ module Jekyll
     class TagAutoPage < BaseAutoPage
       def initialize(site, base, autopage_config, pagination_config, layout_name, tag, tag_name)
 
+        # Do we have a slugify configuration available
+        slugify_config = autopage_config.is_a?(Hash) && autopage_config.has_key?('slugify') ? autopage_config['slugify'] : nil
+
         # Construc the lambda function to set the config values, 
         # this function received the pagination config hash and manipulates it
         set_autopage_data_lambda = lambda do | config |
@@ -11,11 +14,11 @@ module Jekyll
         end
 
         get_autopage_permalink_lambda = lambda do |permalink_pattern|
-          return Utils.format_tag_macro(permalink_pattern, tag, autopage_config['special_characters'])
+          return Utils.format_tag_macro(permalink_pattern, tag, slugify_config)
         end
 
         get_autopage_title_lambda = lambda do |title_pattern|
-          return Utils.format_tag_macro(title_pattern, tag, autopage_config['special_characters'])
+          return Utils.format_tag_macro(title_pattern, tag, slugify_config)
         end
                 
         # Call the super constuctor with our custom lambda

--- a/lib/jekyll-paginate-v2/autopages/utils.rb
+++ b/lib/jekyll-paginate-v2/autopages/utils.rb
@@ -5,20 +5,26 @@ module Jekyll
 
       # Static: returns a fully formatted string with the tag macro (:tag) replaced
       #
-      def self.format_tag_macro(toFormat, tag, special_chars = true)
-        return toFormat.sub(':tag', (special_chars.nil? || special_chars) ? tag.to_s : Jekyll::Utils.slugify(tag.to_s))
+      def self.format_tag_macro(toFormat, tag, slugify_config=nil)
+        slugify_mode = slugify_config.has_key?('mode') ? slugify_config['mode'] : nil
+        slugify_cased = slugify_config.has_key?('cased') ? slugify_config['cased'] : false
+        return toFormat.sub(':tag', Jekyll::Utils.slugify(tag.to_s, mode:slugify_mode, cased:slugify_cased))
       end #function format_tag_macro
 
       # Static: returns a fully formatted string with the category macro (:cat) replaced
       #
-      def self.format_cat_macro(toFormat, category, special_chars = true)
-        return toFormat.sub(':cat', (special_chars.nil? || special_chars) ? category.to_s : Jekyll::Utils.slugify(category.to_s))
+      def self.format_cat_macro(toFormat, category, slugify_config=nil)
+        slugify_mode = slugify_config.has_key?('mode') ? slugify_config['mode'] : nil
+        slugify_cased = slugify_config.has_key?('cased') ? slugify_config['cased'] : false
+        return toFormat.sub(':cat', Jekyll::Utils.slugify(category.to_s, mode:slugify_mode, cased:slugify_cased))
       end #function format_cat_macro
 
       # Static: returns a fully formatted string with the collection macro (:coll) replaced
       #
-      def self.format_coll_macro(toFormat, collection, special_chars = true)
-        return toFormat.sub(':coll', (special_chars.nil? || special_chars) ? collection.to_s : Jekyll::Utils.slugify(collection.to_s))
+      def self.format_coll_macro(toFormat, collection, slugify_config=nil)
+        slugify_mode = slugify_config.has_key?('mode') ? slugify_config['mode'] : nil
+        slugify_cased = slugify_config.has_key?('cased') ? slugify_config['cased'] : false
+        return toFormat.sub(':coll', Jekyll::Utils.slugify(collection.to_s, mode:slugify_mode, cased:slugify_cased))
       end #function format_coll_macro
 
       # Static: returns all documents from all collections defined in the hash of collections passed in


### PR DESCRIPTION
This adds a `special_characters` option to `autopages` to allow the use of spaces and other characters in tags, etc. Basically, if specified, this just omits the slugify step. See #20 

~~~yaml
autopages:
  tags:
    special_characters: true
  categories:
    special_characters: true
  collections:
    special_characters: true
~~~