### PR TITLE
AND/OR filters for tags, categories, and locales

### DIFF
--- a/examples/02-category/categories/pm.md
+++ b/examples/02-category/categories/pm.md
@@ -5,7 +5,8 @@ permalink: /porsche+mercedes
 pagination: 
   enabled: true
   categories:
-    - porsche
-    - mercedes
-  filter: any
+    values:
+      - porsche
+      - mercedes
+    matching: any
 ---

--- a/examples/02-category/categories/pm.md
+++ b/examples/02-category/categories/pm.md
@@ -1,0 +1,11 @@
+---
+layout: home
+title: Porsche & Mercedes
+permalink: /porsche+mercedes
+pagination: 
+  enabled: true
+  categories:
+    - porsche
+    - mercedes
+  filter: any
+---

--- a/examples/02-category/categories/protosports.md
+++ b/examples/02-category/categories/protosports.md
@@ -1,0 +1,12 @@
+---
+layout: home
+title: Prototype Sports Cars
+permalink: /prototype+sportscars
+pagination: 
+  enabled: true
+  categories:
+    values:
+      - prototype
+      - sports car
+    matching: all
+---

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -77,8 +77,7 @@ module Jekyll
         if config[config_key].is_a?(Hash)
           # { values: [..], matching: any|all }
           config_hash = config[config_key]
-          hash_key = config_hash.has_key?('values') ? 'values' : 'value'
-          config_value = Utils.config_values(config_hash, hash_key)
+          config_value = Utils.config_values(config_hash, 'value')
           matching = config_hash['matching'] || 'all'
         else
           # Default array syntax

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -80,7 +80,7 @@ module Jekyll
         filter_key = "#{config_key}_filter"
         filter_value = config[filter_key] || config['filter'] || "all"
 
-        if filter_value.to_s.downcase == "all"
+        if filter_value.to_s.downcase.strip == "all"
           # Now for all filter values for the config key, let's remove all items from the posts that
           # aren't common for all collections that the user wants to filter on
           config_value.each do |key|

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -76,7 +76,7 @@ module Jekyll
         
         if config[config_key].is_a?(Hash) || config[plural_key].is_a?(Hash)
           # { values: [..], matching: any|all }
-          config_hash = config[config_key] || config[plural_key]
+          config_hash = config[config_key].is_a?(Hash) ? config[config_key] : config[plural_key]
           config_value = Utils.config_values(config_hash, 'value')
           matching = config_hash['matching'] || 'all'
         else

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -62,12 +62,12 @@ module Jekyll
       # Filters posts based on a keyed source_posts hash of indexed posts and performs a intersection of 
       # the two sets. Returns only posts that are common between all collections 
       #
-      def self.read_config_value_and_filter_posts(config, config_key, posts, source_posts)
+      def self.read_config_value_and_filter_posts(config, conf_key, posts, source_posts)
         return nil if posts.nil?
         return nil if source_posts.nil? # If the source is empty then simply don't do anything
         return posts if config.nil?
 
-        config_key = config.has_key?(config_key) ? config_key : Utils.plural(config_key)
+        config_key = config.has_key?(conf_key) ? conf_key : Utils.plural(conf_key)
 
         return posts if !config.has_key?(config_key)
         return posts if config[config_key].nil?

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -62,21 +62,21 @@ module Jekyll
       # Filters posts based on a keyed source_posts hash of indexed posts and performs a intersection of 
       # the two sets. Returns only posts that are common between all collections 
       #
-      def self.read_config_value_and_filter_posts(config, conf_key, posts, source_posts)
+      def self.read_config_value_and_filter_posts(config, config_key, posts, source_posts)
         return nil if posts.nil?
         return nil if source_posts.nil? # If the source is empty then simply don't do anything
         return posts if config.nil?
 
-        config_key = config.has_key?(conf_key) ? conf_key : Utils.plural(conf_key)
+        plural_key = Utils.plural(config_key)
 
-        return posts if !config.has_key?(config_key)
-        return posts if config[config_key].nil?
+        return posts if !config.has_key?(config_key) && !config.has_key?(plural_key)
+        return posts if config[config_key].nil? && config[plural_key].nil?
         
         # Get the filter values from the config (this is the cat/tag/locale values that should be filtered on)
         
-        if config[config_key].is_a?(Hash)
+        if config[config_key].is_a?(Hash) || config[plural_key].is_a?(Hash)
           # { values: [..], matching: any|all }
-          config_hash = config[config_key]
+          config_hash = config[config_key] || config[plural_key]
           config_value = Utils.config_values(config_hash, 'value')
           matching = config_hash['matching'] || 'all'
         else

--- a/lib/jekyll-paginate-v2/generator/utils.rb
+++ b/lib/jekyll-paginate-v2/generator/utils.rb
@@ -135,6 +135,27 @@ module Jekyll
         return url
       end
 
+      # Constructs the plural for a key
+      def self.plural(config_key)
+        (config_key =~ /s$/) ? config_key :
+          (config_key.dup.sub!(/y$/, 'ies') || "#{config_key}s")
+      end
+
+      # Converts a string or array to a downcased, stripped array
+      def self.config_array(config, key, keepcase = nil)
+        [ config[key] ].flatten.compact.uniq.map { |c|
+          c.split(/[,;]\s*/).map { |v|
+            keepcase ? v.to_s.strip : v.to_s.downcase.strip
+          }
+        }.flatten.uniq
+      end
+
+      # Merges singular and plural config values into an array
+      def self.config_values(config, key, keepcase = nil)
+        singular = config_array(config, key, keepcase)
+        plural = config_array(config, plural(key), keepcase)
+        [ singular, plural ].flatten.uniq
+      end
     end
 
   end # module PaginateV2


### PR DESCRIPTION
This adds `pagination` options for filtering tags/categories using `all` (and) or `any` (or). See #63.

`category_filter: any|all`: filter for categories
`tag_filter: any|all`: filter for tags
`filter: any|all`: fallback/default if neither of the above is present

Well, actually, it just checks for "all", anything else is considered "any", and the part before the underscore is the `config_key`, so `locale_filter` is also there.

The default is `all` (and) per the current behavior.

This also merges "tag" and "tags", "category" and "categories", etc. during processing so that values in either/both of the variants are used, whether they are strings or arrays.

Example will be at http://localhost:4000/porsche+mercedes/ under `examples/02-category`.