### PR TITLE
Feature: Introductory text for autopages, etc.

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -251,7 +251,8 @@ module Jekyll
         intro = nil
         if intro_file = config['intro']
           using_posts.delete_if { |post| post.basename =~ /(^|-)#{intro_file}$/ && intro = post }
-          intro.data['layout'] = 'none' if !intro.nil?
+          # Override inherited defaults
+          intro.data['layout'] = 'none' if !intro.data.has_key?('layout')
         end
 
         # Calculate the max number of pagination-pages based on the configured per page value

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -248,6 +248,12 @@ module Jekyll
           end
         end
                
+        intro = nil
+        if intro_file = config['intro']
+          using_posts.delete_if { |post| post.basename =~ /(^|-)#{intro_file}$/ && intro = post }
+          intro.data['layout'] = 'none' if !intro.nil?
+        end
+
         # Calculate the max number of pagination-pages based on the configured per page value
         total_pages = Utils.calculate_number_of_pages(using_posts, config['per_page'])
         
@@ -289,8 +295,10 @@ module Jekyll
           end
           paginated_page_url = File.join(first_index_page_url, paginated_page_url)
           
+          pager_intro = cur_page_nr == 1 ? intro : nil
+
           # 3. Create the pager logic for this page, pass in the prev and next page numbers, assign pager to in-memory page
-          newpage.pager = Paginator.new( config['per_page'], first_index_page_url, paginated_page_url, using_posts, cur_page_nr, total_pages, indexPageName, indexPageExt)
+          newpage.pager = Paginator.new( config['per_page'], first_index_page_url, paginated_page_url, using_posts, cur_page_nr, total_pages, indexPageName, indexPageExt, pager_intro)
 
           # Create the url for the new page, make sure we prepend any permalinks that are defined in the template page before
           if newpage.pager.page_path.end_with? '/'

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -252,7 +252,7 @@ module Jekyll
         if intro_file = config['intro']
           using_posts.delete_if { |post| post.basename =~ /(^|-)#{intro_file}$/ && intro = post }
           # Override inherited defaults
-          intro.data['layout'] = 'none' if !intro.data.has_key?('layout')
+          intro.data['layout'] = 'none' if !intro.nil? && !intro.data.has_key?('layout')
         end
 
         # Calculate the max number of pagination-pages based on the configured per page value

--- a/lib/jekyll-paginate-v2/generator/paginator.rb
+++ b/lib/jekyll-paginate-v2/generator/paginator.rb
@@ -7,7 +7,7 @@ module Jekyll
     class Paginator
       attr_reader :page, :per_page, :posts, :total_posts, :total_pages,
         :previous_page, :previous_page_path, :next_page, :next_page_path, :page_path, :page_trail,
-        :first_page, :first_page_path, :last_page, :last_page_path
+        :first_page, :first_page_path, :last_page, :last_page_path, :intro
 
       def page_trail
         @page_trail
@@ -19,7 +19,7 @@ module Jekyll
       
       # Initialize a new Paginator.
       #
-      def initialize(config_per_page, first_index_page_url, paginated_page_url, posts, cur_page_nr, num_pages, default_indexpage, default_ext)
+      def initialize(config_per_page, first_index_page_url, paginated_page_url, posts, cur_page_nr, num_pages, default_indexpage, default_ext, intro = nil)
         @page = cur_page_nr
         @per_page = config_per_page.to_i
         @total_pages = num_pages
@@ -60,6 +60,8 @@ module Jekyll
         @first_page_path = Utils.format_page_number(first_index_page_url, 1, @total_pages)
         @last_page = @total_pages
         @last_page_path = Utils.format_page_number(paginated_page_url, @total_pages, @total_pages)
+
+        @intro = intro
       end
 
       # Convert this Paginator's data to a Hash suitable for use by Liquid.
@@ -81,7 +83,8 @@ module Jekyll
           'first_page_path' => first_page_path,
           'last_page' => last_page,
           'last_page_path' => last_page_path,
-          'page_trail' => page_trail
+          'page_trail' => page_trail,
+          'intro' => intro
         }
       end
       


### PR DESCRIPTION
This implements an "intro" feature as discussed in #58.

Given the following in `_config.yml`:
```yaml
pagination:
  intro: "intro.md"
```
creating a file with the name "intro.md" (or ending in "-intro.md") would insert that file as the introductory text for a collection, posts, etc. according to its location and/or filters (categories, tags, etc.). The file would be fully rendered (Liquid and Markdown) where the following is placed: 

`{{ paginator.intro }}`

Using this could be as simple as dropping an "intro.md" into a collections folder, but the general rule is, as long as you can get an entry to appear uniquely in a pagination page/autopage, you can use it as an intro simply by renaming it and removing its `layout:`, if necessary. 

For example, `examples/03-tags/_romance` could have a file `histrom-intro.md` as follows:

```yaml
---
tags: historical, fiction
---

This is the intro for **Historical Romance** books.
```

and it will be rendered like so after adding `{{ paginator.intro }}` to `_layouts/autopage_collection.html`:

![screenshot 2018-01-29 at 10 56 50 pm](https://user-images.githubusercontent.com/3312209/35518148-a2932d80-054b-11e8-8119-a7a7a9809e67.png)

This also works for posts. Adding `{{ paginator.intro }}` to  `examples/01-typicalblog/_layouts/home.html` and creating `_posts/0000-00-00-main-intro.md` as follows:

```yaml
---
date: 2018-01-29 22:59:19 +0800
---

This is the introduction to the blog.
```
would render as follows:

![screenshot 2018-01-29 at 11 23 12 pm](https://user-images.githubusercontent.com/3312209/35518214-df61877a-054b-11e8-8ead-f51ef6beca6a.png)



