### PR TITLE
Support Jekyll link tag / fix relative_path

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -13,7 +13,11 @@ module Jekyll
         @site = page_to_copy.site
         @base = ''
         @url = ''
-        @name = index_pageandext.nil? ? 'index.html' : index_pageandext
+        if cur_page_nr == 1
+          @name = page_to_copy.relative_path
+        else
+          @name = index_pageandext.nil? ? 'index.html' : index_pageandext
+        end
 
         self.process(@name) # Creates the basename and ext member values
 

--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -14,7 +14,8 @@ module Jekyll
         @base = ''
         @url = ''
         if cur_page_nr == 1
-          @name = page_to_copy.relative_path
+          @dir = File.dirname(page_to_copy.dir)
+          @name = page_to_copy.name
         else
           @name = index_pageandext.nil? ? 'index.html' : index_pageandext
         end


### PR DESCRIPTION
This adds support for [Jekyll's link tag](https://jekyllrb.com/docs/templates/#links) by using the original `dir` and `name` for the first pagination page, based on the [relative_path code](https://github.com/jekyll/jekyll/blob/3fb325998d1bfa55642841d71f73ffa01c925138/lib/jekyll/page.rb#L148-L150). Fixes #77 
