### PR TITLE
Incorporate frontmatter defaults, support :basename etc.

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -23,7 +23,7 @@ module Jekyll
         self.process(@name) # Creates the basename and ext member values
 
         # Copy page data over site defaults
-        defaults = site.frontmatter_defaults.all(page_to_copy.relative_path, type)
+        defaults = @site.frontmatter_defaults.all(page_to_copy.relative_path, type)
         self.data = Jekyll::Utils.deep_merge_hashes(defaults, page_to_copy.data)
 
         if defaults.has_key?('permalink')


### PR DESCRIPTION
This patch uses the site frontmatter defaults applicable to a page, e.g. path and `pages` scope. It also replaces [placeholders supported by pages](https://github.com/jekyll/jekyll/blob/19cd07f059350ecb891918148a4a91af00e4a4d6/lib/jekyll/page.rb#L109-L115)  (i.e. `:path`, `:basename`, and `:output_ext`) in the permalink.

Fixes #74 ... Note that this also has the fix for #77 as that is required to properly generate the `relative_path` required for getting the scoped defaults.