### PR TITLE
Autopages will use tags and categories from all collections

### DIFF
--- a/lib/jekyll-paginate-v2/autopages/pages/categoryAutoPage.rb
+++ b/lib/jekyll-paginate-v2/autopages/pages/categoryAutoPage.rb
@@ -11,6 +11,7 @@ module Jekyll
         # this function received the pagination config hash and manipulates it
         set_autopage_data_lambda = lambda do | in_config |
           in_config['category'] = category
+          in_config['collection'] = site.collections.keys
         end
 
         get_autopage_permalink_lambda = lambda do |permalink_pattern|

--- a/lib/jekyll-paginate-v2/autopages/pages/tagAutoPage.rb
+++ b/lib/jekyll-paginate-v2/autopages/pages/tagAutoPage.rb
@@ -11,6 +11,7 @@ module Jekyll
         # this function received the pagination config hash and manipulates it
         set_autopage_data_lambda = lambda do | config |
           config['tag'] = tag
+          config['collection'] = site.collections.keys
         end
 
         get_autopage_permalink_lambda = lambda do |permalink_pattern|


### PR DESCRIPTION
The paginate options for autopages had `collection` set to posts (a default?)

This patch will create autopages for tags and categories in yaml front matter for all collections in `site.collections`.

In `_config.yml`:
```ruby
collections:
- my_collection
```

In `_my_collection/example.html`:
```
---
title: example
tags:
- a
- b
---
```
running `jekyll build` with autopages enabled will make pages for `tag/a` and `tag/b`.