### PR TITLE
Provide option to bypass delimiter split on keys

### DIFF
--- a/lib/jekyll-paginate-v2/autopages/autoPages.rb
+++ b/lib/jekyll-paginate-v2/autopages/autoPages.rb
@@ -19,7 +19,7 @@ module Jekyll
       # TODO: Should I detect here and disable if we're running the legacy paginate code???!
 
       # Simply gather all documents across all pages/posts/collections that we have
-      # we could be generating quite a few empty pages but the logic is just vastly simpler than trying to 
+      # we could be generating quite a few empty pages but the logic is just vastly simpler than trying to
       # figure out what tag/category belong to which collection.
       posts_to_use = Utils.collect_all_docs(site.collections)
 
@@ -29,7 +29,7 @@ module Jekyll
         site.pages << TagAutoPage.new(site, site.dest, autopage_tag_config, pagination_config, layout_name, tag, tag_original_name)
       end
       autopage_create(autopage_config, pagination_config, posts_to_use, 'tags', 'tags', createtagpage_lambda) # Call the actual function
-      
+
 
       ###############################################
       # Generate the category pages if enabled
@@ -37,14 +37,14 @@ module Jekyll
         site.pages << CategoryAutoPage.new(site, site.dest, autopage_cat_config, pagination_config, layout_name, category, category_original_name)
       end
       autopage_create(autopage_config, pagination_config,posts_to_use, 'categories', 'categories', createcatpage_lambda) # Call the actual function
-      
+
       ###############################################
       # Generate the Collection pages if enabled
       createcolpage_lambda = lambda do | autopage_col_config, pagination_config, layout_name, coll_name, coll_original_name |
         site.pages << CollectionAutoPage.new(site, site.dest, autopage_col_config, pagination_config, layout_name, coll_name, coll_original_name)
       end
       autopage_create(autopage_config, pagination_config,posts_to_use, 'collections', '__coll', createcolpage_lambda) # Call the actual function
-    
+
     end # create_autopages
 
 
@@ -58,7 +58,8 @@ module Jekyll
           Jekyll.logger.info "AutoPages:","Generating #{configkey_name} pages"
 
           # Roll through all documents in the posts collection and extract the tags
-          index_keys = Utils.ap_index_posts_by(posts_to_use, indexkey_name) # Cannot use just the posts here, must use all things.. posts, collections...
+          no_delimiter_config = ap_sub_config ['no_delimiter']
+          index_keys = Utils.ap_index_posts_by(posts_to_use, indexkey_name, no_delimiter_config) # Cannot use just the posts here, must use all things.. posts, collections...
 
           index_keys.each do |index_key, value|
             # Iterate over each layout specified in the config

--- a/lib/jekyll-paginate-v2/autopages/defaults.rb
+++ b/lib/jekyll-paginate-v2/autopages/defaults.rb
@@ -9,6 +9,7 @@ module Jekyll
         'title'         => 'Posts tagged with :tag',
         'permalink'     => '/tag/:tag',
         'enabled'       => true,
+        'no_delimiter'  => false,
         'slugify'       => {
                               'mode' => 'none', # [raw default pretty ascii latin], none gives back the same string
                               'cased'=> false # If cased is true, all uppercase letters in the result string are replaced with their lowercase counterparts.
@@ -19,6 +20,7 @@ module Jekyll
         'title'         => 'Posts in category :cat',
         'permalink'     => '/category/:cat',
         'enabled'       => true,
+        'no_delimiter'  => false,
         'slugify'       => {
                               'mode' => 'none', # [raw default pretty ascii latin], none gives back the same string
                               'cased'=> false # If cased is true, all uppercase letters in the result string are replaced with their lowercase counterparts.
@@ -29,11 +31,12 @@ module Jekyll
         'title'         => 'Posts in collection :coll',
         'permalink'     => '/collection/:coll',
         'enabled'       => true,
+        'no_delimiter'  => false,
         'slugify'       => {
                               'mode' => 'none', # [raw default pretty ascii latin], none gives back the same string
                               'cased'=> false # If cased is true, all uppercase letters in the result string are replaced with their lowercase counterparts.
                             }
-      } 
+      }
     }
 
   end # module PaginateV2::AutoPages

--- a/lib/jekyll-paginate-v2/autopages/utils.rb
+++ b/lib/jekyll-paginate-v2/autopages/utils.rb
@@ -32,14 +32,14 @@ module Jekyll
       def self.collect_all_docs(site_collections)
         coll = []
         site_collections.each do |coll_name, coll_data|
-          if !coll_data.nil? 
+          if !coll_data.nil?
             coll += coll_data.docs.select { |doc| !doc.data.has_key?('pagination') }.each{ |doc| doc.data['__coll'] = coll_name } # Exclude all pagination pages and then for every page store it's collection name
           end
         end
         return coll
       end
 
-      def self.ap_index_posts_by(all_posts, index_key)
+      def self.ap_index_posts_by(all_posts, index_key, no_delimiter=false)
         return nil if all_posts.nil?
         return all_posts if index_key.nil?
         index = {}
@@ -49,19 +49,24 @@ module Jekyll
           next if post.data[index_key].nil?
           next if post.data[index_key].size <= 0
           next if post.data[index_key].to_s.strip.length == 0
-          
+
           # Only tags and categories come as premade arrays, locale does not, so convert any data
           # elements that are strings into arrays
           post_data = post.data[index_key]
           if post_data.is_a?(String)
             post_data = post_data.split(/;|,|\s/)
           end
-          
+
           post_data.each do |key|
             key = key.strip
-            # If the key is a delimetered list of values 
-            # (meaning the user didn't use an array but a string with commas)
-            key.split(/;|,/).each do |raw_k_split|
+            all_keys = unless no_delimiter
+              # If the key is a delimitered list of values
+              # (meaning the user didn't use an array but a string with commas)
+              key.split(/;|,/)
+            else
+              [key]
+            end
+            all_keys.each do |raw_k_split|
               k_split = raw_k_split.to_s.downcase.strip #Clean whitespace and junk
               if !index.has_key?(k_split)
                 # Need to store the original key value here so that I can present it to the users as a page variable they can use (unmodified, e.g. tags not being 'sci-fi' but "Sci-Fi")

--- a/lib/jekyll-paginate-v2/autopages/utils.rb
+++ b/lib/jekyll-paginate-v2/autopages/utils.rb
@@ -58,21 +58,12 @@ module Jekyll
           end
 
           post_data.each do |key|
-            key = key.strip
-            all_keys = unless no_delimiter
-              # If the key is a delimitered list of values
-              # (meaning the user didn't use an array but a string with commas)
-              key.split(/;|,/)
-            else
-              [key]
-            end
-            all_keys.each do |raw_k_split|
-              k_split = raw_k_split.to_s.downcase.strip #Clean whitespace and junk
-              if !index.has_key?(k_split)
-                # Need to store the original key value here so that I can present it to the users as a page variable they can use (unmodified, e.g. tags not being 'sci-fi' but "Sci-Fi")
-                # Also, only interested in storing all the keys not the pages in this case
-                index[k_split.to_s] = [k_split.to_s, raw_k_split.to_s]
-              end
+            key = key.to_s.strip
+            processed_key = key.downcase #Clean whitespace and junk
+            if !index.has_key?(processed_key)
+              # Need to store the original key value here so that I can present it to the users as a page variable they can use (unmodified, e.g. tags not being 'sci-fi' but "Sci-Fi")
+              # Also, only interested in storing all the keys not the pages in this case
+              index[processed_key] = [processed_key, key]
             end
           end
         end


### PR DESCRIPTION
I ran into an autopages issue where I had a category title with a comma in it, and the plugin was interpreting that as multiple categories. My front matter looked like:

```
categories:
- One, Two & Three
```

But instead of getting a category archive for "One, Two & Three", I got "One" and then also "Two & Three".

So I've added a config option where you can set `no_delimiter: true` in the config and that will turn off the key split functionality in the place where that occurs. I'm certainly open to other names for this config option.

Also, I didn't see any specs for autopages, so I didn't write/update a test for this. I've of course tested the branch manually against my Jekyll install (v3.6.2) and it worked as expected with/without this new config set.