### PR TITLE
Compute first_index_page_url from template's url

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -298,14 +298,8 @@ module Jekyll
           newpage = PaginationPage.new( template, cur_page_nr, total_pages, indexPageWithExt )
 
           # 2. Create the url for the in-memory page (calc permalink etc), construct the title, set all page.data values needed
-          paginated_page_url = config['permalink']
-          first_index_page_url = ""
-          if template.data['permalink']
-            first_index_page_url = Utils.ensure_trailing_slash(template.data['permalink'])
-          else
-            first_index_page_url = Utils.ensure_trailing_slash(template.dir)
-          end
-          paginated_page_url = File.join(first_index_page_url, paginated_page_url)
+          first_index_page_url = Utils.template_dest_dir(template)
+          paginated_page_url   = File.join(first_index_page_url, config['permalink'])
           
           # 3. Create the pager logic for this page, pass in the prev and next page numbers, assign pager to in-memory page
           newpage.pager = Paginator.new( config['per_page'], first_index_page_url, paginated_page_url, using_posts, cur_page_nr, total_pages, indexPageName, indexPageExt)

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -298,7 +298,7 @@ module Jekyll
           newpage = PaginationPage.new( template, cur_page_nr, total_pages, indexPageWithExt )
 
           # 2. Create the url for the in-memory page (calc permalink etc), construct the title, set all page.data values needed
-          first_index_page_url = Utils.template_dest_dir(template)
+          first_index_page_url = Utils.validate_url(template)
           paginated_page_url   = File.join(first_index_page_url, config['permalink'])
           
           # 3. Create the pager logic for this page, pass in the prev and next page numbers, assign pager to in-memory page

--- a/lib/jekyll-paginate-v2/generator/utils.rb
+++ b/lib/jekyll-paginate-v2/generator/utils.rb
@@ -157,13 +157,23 @@ module Jekyll
         [ singular, plural ].flatten.uniq
       end
 
-      def self.template_dest_dir(template)
+      def self.validate_url(template)
         url  = template.url
         ext  = template.output_ext
         path = Jekyll::URL.unescape_path(url)
-        path = File.join(path, "index.html") if url.end_with?("/")
+        path = File.join(path, "index") if url.end_with?("/")
         path << ext unless path.end_with?(ext)
-        ensure_trailing_slash(File.dirname(path))
+
+        dirname = File.dirname(path)
+        valid_values = [
+          File.join(dirname, "/"),
+          File.join(dirname, "index#{ext}")
+        ]
+
+        return url if valid_values.include?(url)
+        Jekyll.logger.error "Pagination Error:",
+          "Detected invalid url #{url.inspect} for #{template.relative_path.inspect}"
+        Jekyll.logger.abort_with "", "Expected #{valid_values.map(&:inspect).join(' or ')}"
       end
     end
 

--- a/lib/jekyll-paginate-v2/generator/utils.rb
+++ b/lib/jekyll-paginate-v2/generator/utils.rb
@@ -156,6 +156,15 @@ module Jekyll
         plural = config_array(config, plural(key), keepcase)
         [ singular, plural ].flatten.uniq
       end
+
+      def self.template_dest_dir(template)
+        url  = template.url
+        ext  = template.output_ext
+        path = Jekyll::URL.unescape_path(url)
+        path = File.join(path, "index.html") if url.end_with?("/")
+        path << ext unless path.end_with?(ext)
+        ensure_trailing_slash(File.dirname(path))
+      end
     end
 
   end # module PaginateV2


### PR DESCRIPTION
This is to ensure a proper url when there's an *unconventional* `permalink` defined for the `template_page`
For example, given a `foo/index.html` with the following front matter:
```
---
title: Foo Bar
permalink: foo/bar.html
pagination:
  enabled: true
---
```
the following are the `before` and `after` results:

## Before
```
first_index_page: /foo/bar.html/index.html
 pagination_page: /foo/bar.html/page/:num/index.html
```
## After
```
first_index_page: /foo/index.html
 pagination_page: /foo/page/:num/index.html
```

Thoughts?