### PR TITLE
Set PaginationPage rel_path based on parent page

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -9,10 +9,14 @@ module Jekyll
     # This page exists purely in memory and is not read from disk
     #
     class PaginationPage < Page
+      attr_reader :relative_path
+
       def initialize(page_to_copy, cur_page_nr, total_pages, index_pageandext)
         @site = page_to_copy.site
         @base = ''
-        @url = ''
+        @url  = ''
+        @relative_path = page_to_copy.relative_path
+
         if cur_page_nr == 1
           @dir = File.dirname(page_to_copy.dir)
           @name = page_to_copy.name


### PR DESCRIPTION
Since `PaginationPage` instances are *in-memory-only* objects, they should *ideally* mirror their parent's `relative_path`.

Additional benefits:
- the result for `{{ page.path }}` in the `first_index_page` is the same irrespective of whether pagination is enabled or not
- compute the value once and then refer to the same object thereafter.
- avoids values such as `.html` when `index_pageandext == '.html'`