### PR TITLE
Add an alias_method setter for setting urls

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -312,13 +312,13 @@ module Jekyll
 
           # Create the url for the new page, make sure we prepend any permalinks that are defined in the template page before
           if newpage.pager.page_path.end_with? '/'
-            newpage.set_url(File.join(newpage.pager.page_path, indexPageWithExt))
+            newpage.url = File.join(newpage.pager.page_path, indexPageWithExt)
           elsif newpage.pager.page_path.end_with? indexPageExt
             # Support for direct .html files
-            newpage.set_url(newpage.pager.page_path)
+            newpage.url = newpage.pager.page_path
           else
             # Support for extensionless permalinks
-            newpage.set_url(newpage.pager.page_path+indexPageExt)
+            newpage.url = newpage.pager.page_path + indexPageExt
           end
 
           if( template.data['permalink'] )

--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -56,9 +56,10 @@ module Jekyll
         #Jekyll::Hooks.trigger :pages, :post_init, self
       end
 
-      def set_url(url_value)
+      def url=(url_value)
         @url = @use_permalink_for_url ? self.data['permalink'] : url_value
       end
+      alias_method :set_url, :url=
     end # class PaginationPage
 
   end # module PaginateV2


### PR DESCRIPTION
It is a common convention in Ruby to use a method name with a trailing `=` as the "setter method" for a given instance.
Aliasing the current `PaginationPage#set_url` method name for backwards compatibility