### PR TITLE
CodeClimate: Exclude everything not a `lib/**/*.rb`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,6 +19,17 @@ engines:
         enabled: false
 ratings:
   paths:
-  - "**.rb"
+  - "**/*.rb"
 exclude_paths:
+- "*.*"
+- ".*"
+- "**/*.md"
+- "**/*.yml"
+- "*.gemspec"
+- Gemfile
+- LICENSE
+- Rakefile
+- examples/
+- res/
+- script/
 - spec/


### PR DESCRIPTION
No point analyzing the superfluous files..