### PR TITLE
Set 'index' as the default basename of indexpage

### DIFF
--- a/lib/jekyll-paginate-v2/generator/defaults.rb
+++ b/lib/jekyll-paginate-v2/generator/defaults.rb
@@ -17,7 +17,7 @@ module Jekyll
           'before' => 0, # Limits how many links to show before the current page in the pagination trail (0, means off, default: 0)
           'after' => 0,  # Limits how many links to show after the current page in the pagination trail (0 means off, default: 0)
       },
-      'indexpage'    => nil, # The default name of the index pages
+      'indexpage'    => 'index', # The default name of the index pages
       'extension'    => 'html', # The default extension for the output pages (ignored if indexpage is nil)
       'debug'        => false, # Turns on debug output for the gem
       'legacy'       => false # Internal value, do not use (will be removed after 2018-01-01)


### PR DESCRIPTION
Currently, `PaginationModel` sets `''` as the fallback basename when it is `nil`. Instead, it should be `index` as expected by `PaginationPage`

Resolves #142 