### PR TITLE
Manage category filter if present in the pagination configuration

### DIFF
--- a/lib/jekyll-paginate-v2/autopages/pages/categoryAutoPage.rb
+++ b/lib/jekyll-paginate-v2/autopages/pages/categoryAutoPage.rb
@@ -10,7 +10,15 @@ module Jekyll
         # Construc the lambda function to set the config values
         # this function received the pagination config hash and manipulates it
         set_autopage_data_lambda = lambda do | in_config |
-          in_config['category'] = category
+          if in_config.key?('category')
+            in_config['category'] = in_config['category'] + "," +category
+          else 
+            if in_config.key?('categories')
+              in_config['categories'] << category
+            else
+              in_config['category'] = category
+            end
+          end
           in_config['collection'] = site.collections.keys
         end
 


### PR DESCRIPTION
Pagination can be used with AutoPages.
However, filtering category was overwritten when generating pages by AutoPages for category.
This lightweight changes allows to define `category` or `categories` in the frontpage matter.
For instance, to generate pages for all categories for posts with at least the category "software"

```YAML
---
layout: post
autopages:
  permalink: '/software/category/:cat/'
pagination: 
  enabled: true
  category: software
---
```