### PR TITLE
Added :language macro for frontmatter YML

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -19,8 +19,6 @@ module Jekyll
           next if post.data[index_key].size <= 0
           next if post.data[index_key].to_s.strip.length == 0
             
-          # Jekyll.logger.info "Pag-debug:", post.data.to_json
-          
           # Only tags and categories come as premade arrays, locale does not, so convert any data
           # elements that are strings into arrays
           post_data = post.data[index_key]

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -18,6 +18,8 @@ module Jekyll
           next if post.data[index_key].nil?
           next if post.data[index_key].size <= 0
           next if post.data[index_key].to_s.strip.length == 0
+            
+          # Jekyll.logger.info "Pag-debug:", post.data.to_json
           
           # Only tags and categories come as premade arrays, locale does not, so convert any data
           # elements that are strings into arrays
@@ -31,6 +33,10 @@ module Jekyll
             # If the key is a delimetered list of values 
             # (meaning the user didn't use an array but a string with commas)
             key.split(/;|,/).each do |k_split|
+              # if k_split == ":language"
+              #    k_split = Utils.format_page_lang(k_split, post.data.language)
+              # end
+                
               k_split = k_split.to_s.downcase.strip #Clean whitespace and junk
               if !index.has_key?(k_split)
                 index[k_split.to_s] = []
@@ -62,15 +68,21 @@ module Jekyll
       # Filters posts based on a keyed source_posts hash of indexed posts and performs a intersection of 
       # the two sets. Returns only posts that are common between all collections 
       #
-      def self.read_config_value_and_filter_posts(config, config_key, posts, source_posts)
+      def self.read_config_value_and_filter_posts(config, config_key, posts, source_posts, page_language = nil)
         return nil if posts.nil?
         return nil if source_posts.nil? # If the source is empty then simply don't do anything
         return posts if config.nil?
 
         plural_key = Utils.plural(config_key)
 
+        # Jekyll.logger.info "Pag-debug: ", "Key: " + config_key + " => " + config[config_key]
+          
         return posts if !config.has_key?(config_key) && !config.has_key?(plural_key)
         return posts if config[config_key].nil? && config[plural_key].nil?
+        
+        if config[config_key] == ":language" && !page_language.nil?
+            config[config_key] = config[config_key].sub(':language', page_language)
+        end
         
         # Get the filter values from the config (this is the cat/tag/locale values that should be filtered on)
         

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -33,11 +33,7 @@ module Jekyll
         # Now for each template page generate the paginator for it
         templates.each do |template|
           # All pages that should be paginated need to include the pagination config element
-          if template.data['pagination'].is_a?(Hash)
-            # unless template.data['language'].nil?
-            #     Jekyll.logger.info "Pag-debug-lang: ", template.data['language']
-            # end
-              
+          if template.data['pagination'].is_a?(Hash)          
             template_config = Jekyll::Utils.deep_merge_hashes(default_config, template.data['pagination'] || {})
 
             # Handling deprecation of configuration values

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -34,6 +34,10 @@ module Jekyll
         templates.each do |template|
           # All pages that should be paginated need to include the pagination config element
           if template.data['pagination'].is_a?(Hash)
+            # unless template.data['language'].nil?
+            #     Jekyll.logger.info "Pag-debug-lang: ", template.data['language']
+            # end
+              
             template_config = Jekyll::Utils.deep_merge_hashes(default_config, template.data['pagination'] || {})
 
             # Handling deprecation of configuration values
@@ -64,7 +68,7 @@ module Jekyll
               # TODO: NOTE!!! This whole request for posts and indexing results could be cached to improve performance, leaving like this for now during testing
 
               # Now construct the pagination data for this template page
-              self.paginate(template, template_config, site_title, all_posts, all_tags, all_categories, all_locales)
+              self.paginate(template, template_config, site_title, all_posts, all_tags, all_categories, all_locales, template.data['language'])
             end
           end
         end #for
@@ -217,7 +221,7 @@ module Jekyll
       # template - The index.html Page that requires pagination.
       # config - The configuration settings that should be used
       #
-      def paginate(template, config, site_title, all_posts, all_tags, all_categories, all_locales)
+      def paginate(template, config, site_title, all_posts, all_tags, all_categories, all_locales, page_language = nil)
         # By default paginate on all posts in the site
         using_posts = all_posts
         
@@ -229,7 +233,7 @@ module Jekyll
         using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'tag', using_posts, all_tags)
         self._debug_print_filtering_info('Tag', before, using_posts.size)
         before = using_posts.size
-        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'locale', using_posts, all_locales)
+        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'locale', using_posts, all_locales, page_language)
         self._debug_print_filtering_info('Locale', before, using_posts.size)
         
         # Apply sorting to the posts if configured, any field for the post is available for sorting


### PR DESCRIPTION
With this change, you won't need to create a new file for each locale you need.

Just write: `locale: ":language"`

And depending on language it will change.

Full example:

```yaml
---
layout: index
section-type: index
languages: 
- en
- es
sitemap:
  priority: 1.0
pagination: 
  enabled: true
  locale: ':language'
  permalink: '/:num/'
---
```

I'm using [jekyll-language-plugin](https://github.com/vwochnik/jekyll-language-plugin) together with this.