### PR TITLE
Relaxes Jekyll dependency in gemspec to allow for Jekyll 4.0

### DIFF
--- a/jekyll-paginate-v2.gemspec
+++ b/jekyll-paginate-v2.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   # Gem requires Jekyll to work
   # ~> is the pessimistic operator and is equivalent to '>= 3.0', '< 4.0'
-  spec.add_runtime_dependency "jekyll", "~> 3.0"
+  spec.add_runtime_dependency "jekyll", ">= 3.6", "< 5.0"
 
   # Development requires more
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/jekyll-paginate-v2.gemspec
+++ b/jekyll-paginate-v2.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   # Gem requires Jekyll to work
   # ~> is the pessimistic operator and is equivalent to '>= 3.0', '< 4.0'
-  spec.add_runtime_dependency "jekyll", ">= 3.6", "< 5.0"
+  spec.add_runtime_dependency "jekyll", ">= 3.0", "< 5.0"
 
   # Development requires more
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
This change is recommended for plugin authors by Jekyll [here](https://jekyllrb.com/news/)