### PR TITLE
paginationPage.rb: fix jekyll4 cache mismatch errors

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -14,6 +14,7 @@ module Jekyll
         @base = ''
         @url = ''
         @name = index_pageandext.nil? ? 'index.html' : index_pageandext
+        @path = page_to_copy.path
 
         self.process(@name) # Creates the basename and ext member values
 
@@ -41,6 +42,8 @@ module Jekyll
       end
 
       def set_url(url_value)
+        @path = url_value.delete_prefix '/'
+        @dir  = File.dirname(@path)
         @url = url_value
       end
     end # class PaginationPage


### PR DESCRIPTION
Jekyll 4.0 introduced a new caching mechanism to the LiquidRenderer class. This remembers the paths of any files passed to convert and the rendered output.

The issue here is that Jekyll-Paginate-V2 sets the name of all `Jekyll::PaginateV2::Generator::PaginationPage` instances to index.html. Meaning every pagination page gets rendered to the result of the first paginated page.

This patch simply assigns some fields the Page instance, such that it appears to have the same file name as the file to which it's written to (in the _site directory).