### PR TITLE
Documentation: replace deprecated title_suffix with title, fixes #190

### DIFF
--- a/examples/01-typicalblog/README.md
+++ b/examples/01-typicalblog/README.md
@@ -46,7 +46,7 @@ pagination:
   enabled: true
   per_page: 3
   permalink: '/page/:num/'
-  title_suffix: ' - page :num'
+  title: ':title - page :num'
   limit: 0
   sort_field: 'date'
   sort_reverse: true


### PR DESCRIPTION
Following warning "Deprecation: Pagination: The 'title_suffix' configuration has been deprecated. Please use 'title'. See https://github.com/sverrirs/jekyll-paginate-v2/blob/master/README-GENERATOR.md#site-configuration"