### PR TITLE
Cache mismatch Jekyll 4.0

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -13,7 +13,7 @@ module Jekyll
         @site = page_to_copy.site
         @base = ''
         @url = ''
-        @name = (index_pageandext.nil? || index_pageandext.split('.')[0].length) ? 'index.html' : index_pageandext
+        @name = (index_pageandext.nil? || index_pageandext.split('.')[0].length == 0) ? 'index.html' : index_pageandext
         @path = page_to_copy.path
 
         self.process(@name) # Creates the basename and ext member values

--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -13,7 +13,7 @@ module Jekyll
         @site = page_to_copy.site
         @base = ''
         @url = ''
-	@name = (index_pageandext.nil? || index_pageandext == '.html') ? 'index.html' : index_pageandext
+        @name = (index_pageandext.nil? || index_pageandext == '.html') ? 'index.html' : index_pageandext
         @path = page_to_copy.path
 
         self.process(@name) # Creates the basename and ext member values

--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -13,7 +13,8 @@ module Jekyll
         @site = page_to_copy.site
         @base = ''
         @url = ''
-        @name = index_pageandext.nil? ? 'index.html' : index_pageandext
+        @name = (index_pageandext.nil? || index_pageandext.split('.')[0].length) ? 'index.html' : index_pageandext
+        @path = page_to_copy.path
 
         self.process(@name) # Creates the basename and ext member values
 
@@ -41,6 +42,8 @@ module Jekyll
       end
 
       def set_url(url_value)
+        @path = path[0] == '/' ? path[1..-1] : path
+        @dir = File.dirname(@path)
         @url = url_value
       end
     end # class PaginationPage

--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -13,7 +13,7 @@ module Jekyll
         @site = page_to_copy.site
         @base = ''
         @url = ''
-        @name = (index_pageandext.nil? || index_pageandext.split('.')[0].length == 0) ? 'index.html' : index_pageandext
+	@name = (index_pageandext.nil? || index_pageandext == '.html') ? 'index.html' : index_pageandext
         @path = page_to_copy.path
 
         self.process(@name) # Creates the basename and ext member values

--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -42,7 +42,7 @@ module Jekyll
       end
 
       def set_url(url_value)
-        @path = path[0] == '/' ? path[1..-1] : path
+        @path = url_value[0] == '/' ? url_value[1..-1] : url_value
         @dir = File.dirname(@path)
         @url = url_value
       end


### PR DESCRIPTION
Hello!

I had a problem with `jemoji` rendering on my index page, and pinpointed the problem to the new caching mechanism introduced by Jekyll 4.0. (I had `index.html`, `page1.html` and `page2.html` that required pagination, all of them appeared as `.html` in the Rendering stage)

Carrying on from the work done by @mohkale in #182, I've addressed the latest comments to include `index.html`. This seems to fix my problems, so I've decided to open a PR.

It should now output:
```
         Rendering: bar/index.html
  Pre-Render Hooks: bar/index.html
  Rendering Liquid: bar/index.html
  Rendering Markup: bar/index.html
  Rendering Layout: bar/index.html
         Rendering: foo/index.html
  Pre-Render Hooks: foo/index.html
  Rendering Liquid: foo/index.html
  Rendering Markup: foo/index.html
  Rendering Layout: foo/index.html
```

Thank you in advance for a review :smile: 