### PR TITLE
Option to union rather than intersect paginated posts

### DIFF
--- a/examples/02-category/README.md
+++ b/examples/02-category/README.md
@@ -70,6 +70,30 @@ Page 2: http://localhost:4000/porsches/2/
 Page N: http://localhost:4000/porsches/N/
 ```
 
+### Categories/toyota-or-porsche.md
+This is a more complex category pagination similar to the `porsche.md` setup, but this sets the combine option to union to include posts with toyota or porsche. The configuration for the page looks like this:
+
+``` yml
+---
+layout: home
+title: Toyota or Porsche
+permalink: /toyota-or-porsches/
+pagination:
+  enabled: true
+  category: toyota, porsche
+  combine: union
+  permalink: /:num/
+---
+```
+
+The paging list posts with the category `toyota` or `porsche`.
+
+```
+Page 1: http://localhost:4000/toyota-or-porsche/
+Page 2: http://localhost:4000/toyota-or-porsche/2/
+Page N: http://localhost:4000/toyota-or-porsche/N/
+```
+
 ### Categories/byname.md
 This pagination page expands on the the first two examples by adding a custom sorting for the category pagination. It displays all cars but by alphabetical order by Car name.
 

--- a/examples/02-category/categories/toyota-or-porsche.md
+++ b/examples/02-category/categories/toyota-or-porsche.md
@@ -1,0 +1,11 @@
+---
+layout: home
+title: Toyota or Porsche
+permalink: /toyota-or-porsches/
+pagination:
+  enabled: true
+  category: toyota, porsche
+  combine: union
+  permalink: /:num/
+---
+

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -59,10 +59,26 @@ module Jekyll
       end #function intersect_arrays
       
       #
-      # Filters posts based on a keyed source_posts hash of indexed posts and performs a intersection of 
-      # the two sets. Returns only posts that are common between all collections 
+      # Creates a union (returns unique elements from both)
+      # between multiple arrays
       #
-      def self.read_config_value_and_filter_posts(config, config_key, posts, source_posts)
+      def self.union_arrays(first, *rest)
+        return nil if first.nil?
+        return nil if rest.nil?
+
+        union = first
+        rest.each do |item|
+          return [] if item.nil?
+          union = union | item
+        end
+        return union
+      end #function union_arrays
+
+      #
+      # Filters posts based on a keyed source_posts hash of indexed posts and performs a intersection of
+      # the two sets. Returns only posts that are common between all collections
+      #
+      def self.read_config_value_and_filter_posts(config, config_key, posts, source_posts, should_union = false)
         return nil if posts.nil?
         return nil if source_posts.nil? # If the source is empty then simply don't do anything
         return posts if config.nil?
@@ -81,7 +97,11 @@ module Jekyll
         # aren't common for all collections that the user wants to filter on
         config_value.each do |key|
           key = key.to_s.downcase.strip
-          posts = PaginationIndexer.intersect_arrays(posts, source_posts[key])
+          posts = if should_union
+            PaginationIndexer.union_arrays(posts, source_posts[key])
+          else
+            PaginationIndexer.intersect_arrays(posts, source_posts[key])
+          end
         end
         
         # The fully filtered final post list

--- a/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationIndexer.rb
@@ -95,6 +95,8 @@ module Jekyll
           
         # Now for all filter values for the config key, let's remove all items from the posts that
         # aren't common for all collections that the user wants to filter on
+        posts = [] if should_union
+
         config_value.each do |key|
           key = key.to_s.downcase.strip
           posts = if should_union

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -159,6 +159,7 @@ module Jekyll
           puts f + " Active Filters"
           puts f + "  Collection: ".ljust(r) + config['collection'].to_s
           puts f + "  Offset: ".ljust(r) + config['offset'].to_s
+          puts f + "  Combine: ".ljust(r) + config['combine'].to_s
           puts f + "  Category: ".ljust(r) + (config['category'].nil? || config['category'] == "posts" ? "[Not set]" : config['category'].to_s)
           puts f + "  Tag: ".ljust(r) + (config['tag'].nil? ? "[Not set]" : config['tag'].to_s)
           puts f + "  Locale: ".ljust(r) + (config['locale'].nil? ? "[Not set]" : config['locale'].to_s)
@@ -207,16 +208,18 @@ module Jekyll
       def paginate(template, config, site_title, all_posts, all_tags, all_categories, all_locales)
         # By default paginate on all posts in the site
         using_posts = all_posts
-        
+
+        should_union = config['combine'] == 'union'
+
         # Now start filtering out any posts that the user doesn't want included in the pagination
         before = using_posts.size.to_i
-        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'category', using_posts, all_categories)
+        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'category', using_posts, all_categories, should_union)
         self._debug_print_filtering_info('Category', before, using_posts.size.to_i)
         before = using_posts.size.to_i
-        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'tag', using_posts, all_tags)
+        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'tag', using_posts, all_tags, should_union)
         self._debug_print_filtering_info('Tag', before, using_posts.size.to_i)
         before = using_posts.size.to_i
-        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'locale', using_posts, all_locales)
+        using_posts = PaginationIndexer.read_config_value_and_filter_posts(config, 'locale', using_posts, all_locales, should_union)
         self._debug_print_filtering_info('Locale', before, using_posts.size.to_i)
         
         # Apply sorting to the posts if configured, any field for the post is available for sorting

--- a/spec/generator/paginationIndexer_spec.rb
+++ b/spec/generator/paginationIndexer_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../spec_helper.rb'
+
+module Jekyll::PaginateV2::Generator
+  describe PaginationIndexer do
+
+    it "must intersect arrays" do
+      first = [1, 2, 3, 4, nil]
+      second = [2, 3, 4, 5]
+      third = [3, 4, 5, 6]
+      wildcard = [1, nil]
+
+      first_second = PaginationIndexer.intersect_arrays(first, second)
+      first_second.must_equal [2, 3, 4]
+
+      first_wildcard = PaginationIndexer.intersect_arrays(first, wildcard)
+      first_wildcard.must_equal [1, nil]
+
+      not_wildcard = PaginationIndexer.intersect_arrays(first, second, third)
+      not_wildcard.must_equal [3, 4]
+    end
+
+    it "must union arrays" do
+      first = [1, 2, 3, 4, nil]
+      second = [2, 3, 4, 5]
+      third = [3, 4, 5, 6]
+      wildcard = [1, nil]
+
+      first_second = PaginationIndexer.union_arrays(first, second)
+      first_second.must_equal [1, 2, 3, 4, nil, 5]
+
+      first_wildcard = PaginationIndexer.union_arrays(first, wildcard)
+      first_wildcard.must_equal [1, 2, 3, 4, nil]
+
+      not_wildcard = PaginationIndexer.union_arrays(first, second, third)
+      not_wildcard.must_equal [1, 2, 3, 4, nil, 5, 6]
+    end
+  end
+end


### PR DESCRIPTION
The current behaviour when specifying multiple categories, tags and locales on a pagination page is to filter posts that include **all** of these.

For example, this shows all posts with **both** the food and animal categories:

```
pagination:
  category: food, animal
```

This pull request adds a `combine: union` option which can change that behaviour to filter posts that have **at least one** of the specified categories, tags and locales.

For example, this shows all posts with **either** the food and animal categories:

```
pagination:
  category: food, animal
  combine: union
```

I've added a couple of tests and modified the example to demonstrate how to use it. I'm currently using this fork on a site to achieve this. It'd be great to refer to the main repo instead, let me know if there's anything further I can do.