### PR TITLE
Improve compatibility with other plugins that access page.path

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -32,6 +32,9 @@ module Jekyll
         # Store the current page and total page numbers in the pagination_info construct
         self.data['pagination_info'] = {"curr_page" => cur_page_nr, 'total_pages' => total_pages }       
 
+        # Map the first page back to the source file path, to play nice with other plugins
+        self.data['path'] = page_to_copy.path if cur_page_nr == 1
+
         # Perform some validation that is also performed in Jekyll::Page
         validate_data! page_to_copy.path
         validate_permalink! page_to_copy.path


### PR DESCRIPTION
The current behaviour of this plugin involves deleting the initial pagination pages, and then re-adding them as the first paginated page.

In most cases, this page is added back with the internal path set to ".html". The only exception is when the `indexpage` option is provided, the path is changed as a side effect.

This pull request restores the original file path for the first pagination page, which allows any plugin running after pagination to inspect or affect the first page in a sane manner.

The page data as it leaves this plugin is currently, generally:
```
{
  "name":".html",
  "path":".html",
  "url":"/blog/index.html",
  ...
}
```

This pull request amends the first page to have the following data:
```
{
  "name":".html",
  "path":"blog/index.html",
  "url":"/blog/index.html",
  ...
}
```

Any subsequent pages are left untouched, as they have no source file to map back to.

The acute case for this behaviour is better compatibility with the [cloudcannon-jekyll](https://github.com/CloudCannon/cloudcannon-jekyll) plugin. I also imagine this will help most plugins that happen to run after pagination.