### PR TITLE
Retain page extension after pagination

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -32,6 +32,9 @@ module Jekyll
         # Store the current page and total page numbers in the pagination_info construct
         self.data['pagination_info'] = {"curr_page" => cur_page_nr, 'total_pages' => total_pages }       
 
+        # Retain the extention so the page exists in site.html_pages
+        self.ext = page_to_copy.ext
+
         # Perform some validation that is also performed in Jekyll::Page
         validate_data! page_to_copy.path
         validate_permalink! page_to_copy.path


### PR DESCRIPTION
The current behaviour of this plugin involves creating synthetic pages for pagination, based on the initial pagination file.

In all cases, these pages are added back without `page.ext` being set. This causes `page.output_exts` to be empty, which causes the initial page to disappear from `site.html_pages`, and the paginated pages to not appear.

This pull request transfers the original extension to the paginated pages, which allows any plugin running after pagination to inspect or affect the output pages.

The acute case for this behaviour is better compatibility with the cloudcannon-jekyll plugin. I also imagine this will help most plugins that happen to run after pagination.