### PR TITLE
Bugfix: should add extension, not index name

### DIFF
--- a/lib/jekyll-paginate-v2/generator/utils.rb
+++ b/lib/jekyll-paginate-v2/generator/utils.rb
@@ -129,7 +129,7 @@ module Jekyll
         if( url.end_with?('/'))
           return url + default_index + default_ext
         elsif !url.include?('.')
-          return url + default_index
+          return url + default_ext
         end
         # Default
         return url


### PR DESCRIPTION
I believe this is a typo in the code, you mean to add the default extension when the url doesn't include a `.` i.e. is extensionless.

This bug drove me mad for hours as the paginator refused to create clean files like `/news/2.html`, `/news/3.html`