### PR TITLE
Set page dir so link tag works with pagination pages

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -48,6 +48,10 @@ module Jekyll
 
       def set_url(url_value)
         @url = url_value
+
+        # Set dir now that url has been set, as dir is calculated from the url - dir is in turn used to
+        # set the relative_path, which we need to link to the pagination page using the link tag
+        @dir = dir
       end
     end # class PaginationPage
 


### PR DESCRIPTION
Hi there, I've not opened a new issue for this because it's essentially the same as the closed issue #104  - let me know if you'd like me to create a new issue for this PR.

To recap #104,  currently the `link` tag doesn't work for paginated pages that aren't in the root directory. This is because when the paginated page is copied, `page.dir` isn't set. Then `page.relative_path` (which is what the `link` tag looks for) is in turn [set by joining dir and name.](https://github.com/jekyll/jekyll/blob/e1838db15684f2fe40ca929f6eac824214cbe3d3/lib/jekyll/page.rb#L145)

In this PR, I'm setting `@dir` in the `set_url` method after `@url` is set because I'm using the inherited `dir` method from the Jekyll `Page` class [which uses the url to get dir.](https://github.com/jekyll/jekyll/blob/e1838db15684f2fe40ca929f6eac824214cbe3d3/lib/jekyll/page.rb#L65)

I'm aware that this change means the `set_url` method doesn't just set the url. There are a few options:
1. rename the method to something like `set_url_dir`
2. create a new `PaginationPage` method called `set_dir` to be called after `set_url` is called in `paginationModel.rb`, or
3. leave it as is if you think this is reasonable. 

