### PR TITLE
Added the option to prevent empty pages generation.

### DIFF
--- a/README-GENERATOR.md
+++ b/README-GENERATOR.md
@@ -50,6 +50,9 @@ pagination:
   # Site-wide kill switch, disabled here it doesn't run at all 
   enabled: true
 
+  # Prevent empty pages to be printed
+  allow_empty_pages: false
+
   # Set to 'true' to enable pagination debugging. This can be enabled in the site config or only for individual pagination pages
   debug: false
 

--- a/lib/jekyll-paginate-v2/generator/paginationModel.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationModel.rb
@@ -276,7 +276,7 @@ module Jekyll
         indexPageWithExt = indexPageName + indexPageExt
 
         # In case there are no (visible) posts, generate the index file anyway
-        total_pages = 1 if total_pages.zero?
+        total_pages = 1 if total_pages.zero? && config['allow_empty_pages']
 
         # Now for each pagination page create it and configure the ranges for the collection
         # This .pager member is a built in thing in Jekyll and defines the paginator implementation


### PR DESCRIPTION
In my specific case, I was using a custom generator to filter categories on a multilingual page, where categories are also translated, and I wanted paginated pages split by language.

Everything works fine except for the redundant pages generated: under the `/en/categories/` path, I had the full list of terms in English and Italian, where the Italian ones were, as expected, pointing to empty pages.

The same situation was reflected under `/it/categorie/`, where the empty pages are those related to the English terms.

So, imagining adding more languages and more terms, the situation would get even worse.

My patch allows to exclude by default the empty pages, and re-enables the old behaviour by setting a specific setting in the config section.
